### PR TITLE
Fix scala-labs clone URL

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -20,7 +20,7 @@ You will need the following tools:
   	
   		<p>
   			To clone the scala-labs repo, use the following command:<br>
-  			<code>git clone --recursive git@github.com/scala-labs/scala-labs.git</code>
+  			<code>git clone --recursive git@github.com:scala-labs/scala-labs.git</code>
   		</p>
     </li>
 	</p>


### PR DESCRIPTION
Fix the URL for cloning scala-labs from Github.